### PR TITLE
[FEAT] 펫시터/게시판 목록 썸네일 표시

### DIFF
--- a/src/components/Admin/DashBoard.jsx
+++ b/src/components/Admin/DashBoard.jsx
@@ -88,7 +88,7 @@ function DashBoard() {
                 title: item.title,
                 content: item.content,
                 authorNickname: item.authorNickname,
-                image: item.imageUrls && item.imageUrls.length > 0 ? item.imageUrls[0].url : null,
+                image: item.firstImageUrl,
                 likeCount: item.likeCount,
                 date: new Date(item.createdAt).toLocaleString(),
             }));
@@ -199,7 +199,7 @@ function DashBoard() {
                                                 {row.id}
                                             </TableCell>
                                             <TableCell sx={{ ...cellStyles.image }}>
-                                                {row.image && row.image.length > 0 ? (
+                                                {row.firstImageUrl ? (
                                                     <Box
                                                         component="img"
                                                         sx={{
@@ -208,7 +208,7 @@ function DashBoard() {
                                                             objectFit: "cover",
                                                             borderRadius: "4px",
                                                         }}
-                                                        src={row.image}
+                                                        src={row.firstImageUrl}
                                                         alt="썸네일"
                                                         onError={(e) => {
                                                             e.target.src = "/src/assets/images/default-thumbnail.png"; // 기본 이미지 경로로 대체

--- a/src/components/Admin/PetsitterList.jsx
+++ b/src/components/Admin/PetsitterList.jsx
@@ -1,6 +1,17 @@
 import React, { useEffect, useState } from "react";
 import AdminHeader from "./AdminHeader.jsx";
-import { Box, Button, Table, TableBody, TableCell, TableContainer, TableHead, TableRow } from "@mui/material";
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+} from "@mui/material";
 import Layout from "./Layout.jsx";
 import { useNavigate } from "react-router-dom";
 import { useAdmin } from "./AdminContext.jsx";
@@ -22,8 +33,8 @@ const PetsitterList = () => {
     // 각 열에 대한 스타일 객체를 미리 정의
     const cellStyles = {
         id: { width: 80, minWidth: 80, maxWidth: 80 },
-        sitterExp: { width: 100, minWidth: 100, maxWidth: 100 },
         image: { width: 150, minWidth: 150, maxWidth: 150 },
+        sitterExp: { width: 100, minWidth: 100, maxWidth: 100 },
         nickname: { width: 150, minWidth: 150, maxWidth: 150 },
         age: { width: 100, minWidth: 100, maxWidth: 100 },
         grown: { width: 150, minWidth: 150, maxWidth: 150 },
@@ -67,9 +78,9 @@ const PetsitterList = () => {
             // API 응답 가공
             const transformedData = response.content.map((item) => ({
                 id: item.id,
+                image: item.imagePath,
                 sitterExp: item.sitterExp,
                 grown: item.grown,
-                image: item.imagePath && item.imagePath.length > 0 ? item.imagePath[0].url : null,
                 nickname: item.nickname,
                 age: item.age,
                 petCount: item.petCount,
@@ -126,6 +137,20 @@ const PetsitterList = () => {
         <Layout>
             <AdminHeader onSearch={handleSearch} onFilterChange={handleFilterChange} />
 
+            {/* 로딩 상태 표시 */}
+            {loading && (
+                <Box sx={{ display: "flex", alignItems: "center", my: 4 }}>
+                    <CircularProgress />
+                </Box>
+            )}
+
+            {/* 에러 메시지 표시 */}
+            {error && (
+                <Alert severity="error" sx={{ my: 2 }}>
+                    {error}
+                </Alert>
+            )}
+
             {/* 테이블 부분 */}
             <Box>
                 {!loading && !error && (
@@ -134,10 +159,10 @@ const PetsitterList = () => {
                             <TableHead>
                                 <TableRow>
                                     <TableCell sx={{ ...cellStyles.id, ...commonCellStyle }}>ID</TableCell>
+                                    <TableCell sx={{ ...cellStyles.image, ...commonCellStyle }}>사진</TableCell>
                                     <TableCell sx={{ ...cellStyles.sitterExp, ...commonCellStyle }}>
                                         펫시터 경험
                                     </TableCell>
-                                    <TableCell sx={{ ...cellStyles.image, ...commonCellStyle }}>사진</TableCell>
                                     <TableCell sx={{ ...cellStyles.nickname, ...commonCellStyle }}>
                                         사용자 아이디
                                     </TableCell>
@@ -173,11 +198,8 @@ const PetsitterList = () => {
                                             >
                                                 {row.id}
                                             </TableCell>
-                                            <TableCell sx={{ ...cellStyles.sitterExp, ...commonCellStyle }}>
-                                                {row.sitterExp ? "있음" : "없음"}
-                                            </TableCell>
                                             <TableCell sx={{ ...cellStyles.image }}>
-                                                {row.image && row.image.length > 0 ? (
+                                                {row.image ? (
                                                     <Box
                                                         component="img"
                                                         sx={{
@@ -206,6 +228,9 @@ const PetsitterList = () => {
                                                         No Image
                                                     </Box>
                                                 )}
+                                            </TableCell>
+                                            <TableCell sx={{ ...cellStyles.sitterExp, ...commonCellStyle }}>
+                                                {row.sitterExp ? "있음" : "없음"}
                                             </TableCell>
                                             <TableCell sx={{ ...cellStyles.nickname, ...commonCellStyle }}>
                                                 {row.nickname}


### PR DESCRIPTION
## 📢 작업 내용
- 펫시터/게시판 목록 썸네일 표시

## 🔎 변경 사항
-

## 🚀 테스트 방법
-

## 📸 스크린샷 (필수)
![image](https://github.com/user-attachments/assets/f893d1b1-b050-460b-b1fd-caffcba06aa5)

## 💡 추가 설명
- object storage에 파일이 없어서 깨져보임

## ⛓️ 관련 이슈
- #145 

Closes #145 
