### PR TITLE
[FIX] 관리자 업체등록 이미지 수정 3차

### DIFF
--- a/src/components/Admin/DashBoard.jsx
+++ b/src/components/Admin/DashBoard.jsx
@@ -141,13 +141,6 @@ function DashBoard() {
                 </Alert>
             )}
 
-            {/* 검색 상태 표시 */}
-            {/*{searchTerm && (*/}
-            {/*    <Alert severity="info" sx={{ my: 2 }}>*/}
-            {/*        "{searchField}"(으)로 "{searchTerm}" 검색 결과*/}
-            {/*    </Alert>*/}
-            {/*)}*/}
-
             {/* 테이블 부분 */}
             <Box>
                 {!loading && !error && (

--- a/src/components/Admin/FacilityAdd.jsx
+++ b/src/components/Admin/FacilityAdd.jsx
@@ -712,7 +712,7 @@ const FacilityAdd = () => {
                         <Box sx={{ float: "left", width: "100%" }}>
                             <Grid container spacing={2}>
                                 {/* 첫 번째 열: 업종 */}
-                                <Grid item xs={12} sm={6} sx={{ width: "20%" }}>
+                                <Grid item xs={12} sm={6} sx={{ width: "10%" }}>
                                     <FormControl size="medium" fullWidth>
                                         <InputLabel>업종</InputLabel>
                                         <Select
@@ -727,15 +727,24 @@ const FacilityAdd = () => {
                                     </FormControl>
                                 </Grid>
 
-                                <Grid item xs={12} sm={6} sx={{ width: "40%" }}>
+                                <Grid item xs={12} sm={6} sx={{ width: "20%" }}>
                                     <TextField
                                         fullWidth
                                         label="업체 전화번호"
-                                        placeholder="업체 전화번호"
+                                        placeholder="01012341234"
                                         value={tel}
-                                        onChange={(e) => setTel(e.target.value)}
+                                        onChange={(e) => {
+                                            const onlyNums = e.target.value.replace(/\D/g, ""); // 숫자만 필터
+                                            if (onlyNums.length <= 11) {
+                                                setTel(onlyNums);
+                                            }
+                                        }}
                                         variant="outlined"
                                         size="medium"
+                                        inputProps={{
+                                            inputMode: "numeric",
+                                            maxLength: 11,
+                                        }}
                                     />
                                 </Grid>
 
@@ -957,8 +966,8 @@ const FacilityAdd = () => {
                         )}
                     </Box>
 
-                    <Grid container spacing={2} sx={{ height: "60px" }}>
-                        <Grid item xs={12} sm={4} sx={{ width: "20%" }}>
+                    <Grid container spacing={2} sx={{ height: "auto", flexWrap: "wrap" }}>
+                        <Grid item xs={12} sm={2}>
                             {!isZipCodeFound ? (
                                 <Button
                                     variant="contained"
@@ -978,16 +987,6 @@ const FacilityAdd = () => {
                                 </Button>
                             ) : (
                                 <Box sx={{ display: "flex", gap: 1 }}>
-                                    <TextField
-                                        fullWidth
-                                        label="우편번호"
-                                        value={zipCode}
-                                        variant="outlined"
-                                        size="medium"
-                                        InputProps={{
-                                            readOnly: true,
-                                        }}
-                                    />
                                     <Button
                                         variant="outlined"
                                         onClick={() => {
@@ -1009,10 +1008,20 @@ const FacilityAdd = () => {
                                     >
                                         <CloseIcon />
                                     </Button>
+                                    <Box sx={{ width: "100px" }}>
+                                        <TextField
+                                            fullWidth
+                                            label="우편번호"
+                                            value={zipCode}
+                                            variant="outlined"
+                                            size="medium"
+                                            InputProps={{ readOnly: true }}
+                                        />
+                                    </Box>
                                 </Box>
                             )}
                         </Grid>
-                        <Grid item xs={12} sm={4} sx={{ width: "30%" }}>
+                        <Grid item xs={12} md={3}>
                             <TextField
                                 fullWidth
                                 label="기본주소"
@@ -1026,7 +1035,7 @@ const FacilityAdd = () => {
                                 }}
                             />
                         </Grid>
-                        <Grid item xs={12} sm={4} sx={{ width: "47.8%" }}>
+                        <Grid item xs={12} md={7}>
                             <TextField
                                 fullWidth
                                 label="상세주소"
@@ -1035,6 +1044,7 @@ const FacilityAdd = () => {
                                 onChange={(e) => setDetailAddress(e.target.value)}
                                 variant="outlined"
                                 size="medium"
+                                sx={{ width: "400px" }}
                             />
                         </Grid>
                     </Grid>

--- a/src/components/Admin/FacilityDetail.jsx
+++ b/src/components/Admin/FacilityDetail.jsx
@@ -180,7 +180,10 @@ const FacilityDetail = () => {
                                             <OpeningHoursRow openingHours={facility.openingHours} />
                                         )}
                                         <TableRow label="설명" value={facility.comment} />
-                                        <TableRow label="등록일자" value={facility.createdAt} />
+                                        <TableRow
+                                            label="등록일자"
+                                            value={new Date(facility.createdAt).toLocaleString()}
+                                        />
                                     </tbody>
                                 </table>
                             </Box>

--- a/src/components/Admin/FacilityUpdate.jsx
+++ b/src/components/Admin/FacilityUpdate.jsx
@@ -167,20 +167,31 @@ const FacilityUpdate = () => {
             // console.log("longitude: " + longitude);
 
             // 이미지 처리 (예외 처리 수정)
-            if (facility.images && Array.isArray(facility.images)) {
-                console.log("이미지 데이터:", facility.images);
+            if (facility.imagePaths && Array.isArray(facility.imagePaths)) {
+                console.log("이미지 데이터:", facility.imagePaths);
 
                 // 이미지 URL 설정
-                const urls = facility.images.map((img) => img.url);
-                setExistingImages(urls);
-                console.log("설정된 이미지 URL:", urls);
+                setExistingImages(facility.imagePaths);
+
+                // URL에서 파일 경로만 추출 (물음표 이전 부분)
+                const filePathsOnly = facility.imagePaths
+                    .map((url) => {
+                        const pathOnly = url.split("?")[0]; // URL 쿼리 파라미터 제거
+
+                        // 파일 경로만 추출 (예: uploads/facility/file.jpg)
+                        const pathMatch = pathOnly.match(/uploads\/facility\/([^\/]+)$/);
+                        if (pathMatch && pathMatch[1]) {
+                            return pathMatch[1]; // 파일명만 추출
+                        }
+                        return null;
+                    })
+                    .filter((path) => path !== null);
 
                 // 이미지 ID 설정
-                const ids = facility.images.map((img) => img.id);
-                setExistingImageIds(ids);
-                console.log("설정된 이미지 ID:", ids);
+                setExistingImageIds(filePathsOnly);
+                console.log("추출된 파일 경로: " + filePathsOnly);
             } else {
-                console.warn("이미지 데이터가 없거나 배열이 아님:", facility.images);
+                console.warn("이미지 데이터가 없거나 배열이 아님:", facility.imagePaths);
                 setExistingImages([]);
                 setExistingImageIds([]);
             }
@@ -560,10 +571,7 @@ const FacilityUpdate = () => {
         const newExistingImageIds = [...existingImageIds];
 
         newExistingImages.splice(index, 1);
-
-        if (index < newExistingImageIds.length) {
-            newExistingImageIds.splice(index, 1);
-        }
+        newExistingImageIds.splice(index, 1);
 
         setExistingImages(newExistingImages);
         setExistingImageIds(newExistingImageIds);
@@ -689,16 +697,11 @@ const FacilityUpdate = () => {
         // 유지할 이미지 ID 추가
         console.log("existingImageIds (원본):", existingImageIds);
 
-        // 유지할 이미지 ID 배열에서 유효한 ID만 필터링
-        const validImageIds = existingImageIds.filter((id) => id !== null && !isNaN(id) && id > 0);
-
-        console.log("validImageIds (필터링 후):", validImageIds);
-
-        // 2. 유효한 이미지 ID가 있는 경우만 추가
-        if (validImageIds.length > 0) {
+        // 이미지 ID가 있는 경우만 추가
+        if (existingImageIds.length > 0) {
             // 문자열로 직접 폼데이터에 추가
-            formData.append("imageIdsToKeep", JSON.stringify(validImageIds));
-            console.log("유지할 이미지 ID 추가됨:", JSON.stringify(validImageIds));
+            formData.append("imageIdsToKeep", JSON.stringify(existingImageIds));
+            console.log("유지할 이미지 ID 추가됨:", JSON.stringify(existingImageIds));
         } else {
             // 빈 배열이라도 명시적으로 추가 (서버에서 null 대신 빈 배열로 받게)
             formData.append("imageIdsToKeep", JSON.stringify([]));

--- a/src/components/Admin/PetsitterList.jsx
+++ b/src/components/Admin/PetsitterList.jsx
@@ -193,8 +193,8 @@ const PetsitterList = () => {
                                                     <Box
                                                         component="img"
                                                         sx={{
-                                                            height: 50,
-                                                            width: 60,
+                                                            height: 100,
+                                                            width: 100,
                                                             objectFit: "cover",
                                                             borderRadius: "4px",
                                                         }}

--- a/src/components/Admin/PostDetail.jsx
+++ b/src/components/Admin/PostDetail.jsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect } from "react";
-import { Box, Typography, Card, Button, CardMedia, Paper, Stack, Grid, CircularProgress, Alert } from "@mui/material";
+import { Box, Typography, Card, Button, Paper, Stack, Grid, CircularProgress, Alert } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import AdminHeader from "./AdminHeader.jsx";
 import { fetchBoardDetail } from "./adminBoardApi.js";
 import { useNavigate, useParams } from "react-router-dom";
 import { useAdmin } from "./AdminContext.jsx";
 import adminAxios from "./adminAxios.js";
+import ImageSlider from "./ImageSlider.jsx";
 
 // 커스텀 스타일 컴포넌트 생성
 const PostHeader = styled(Box)(({ theme }) => ({
@@ -138,22 +139,36 @@ const PostDetail = () => {
                             <Typography variant="body2">작성자 : {board.authorNickname || board.author}</Typography>
                             <Typography variant="body2">댓글 갯수 : {board.commentCount || 0}개</Typography>
                         </PostInfo>
+                        {board.sell != null && board.price != null && (
+                            <PostInfo>
+                                <Typography variant="body1" color="text.primary">
+                                    가격: {board.price}원
+                                </Typography>
+                                <Typography variant="body1" color="text.primary">
+                                    {board.sell === true ? "판매중" : "판매 완료"}
+                                </Typography>
+                            </PostInfo>
+                        )}
 
                         {/* 게시글 내용 */}
                         <PostContent>
                             {/* 게시글 이미지 - 이미지가 있는 경우에만 표시 */}
                             {board.imageUrls && board.imageUrls.length > 0 && (
-                                <CardMedia
-                                    component="img"
-                                    sx={{ width: 300, height: 200, mb: 2, objectFit: "cover" }}
-                                    image={board.imageUrls[0].url}
-                                    alt="게시글 이미지"
-                                />
+                                <Box sx={{ display: "flex", justifyContent: "center", mb: 4 }}>
+                                    <ImageSlider images={board.imageUrls || []} />
+                                </Box>
                             )}
 
                             <Typography variant="body1" color="text.primary" paragraph>
                                 {board.content}
                             </Typography>
+                            {board.authorAddress != null && (
+                                <PostInfo>
+                                    <Typography variant="body1" color="text.primary">
+                                        거래장소: {board.authorAddress}
+                                    </Typography>
+                                </PostInfo>
+                            )}
                         </PostContent>
 
                         {/* 작업 버튼 영역 */}

--- a/src/components/Admin/adminBoardApi.js
+++ b/src/components/Admin/adminBoardApi.js
@@ -43,6 +43,7 @@ export const fetchBoardDetail = async (boardId) => {
             throw new Error(response.data.message || "게시글 정보를 가져오는데 실패했습니다");
         }
 
+        console.log(response.data);
         return response.data;
     } catch (error) {
         console.error("게시글 상세정보 API 호출 중 오류 발생: " + error);


### PR DESCRIPTION
## 📢 작업 내용
관리자 업체등록 이미지 수정 3차

## 🔎 변경 사항
- 관리자 업체 수정시 기존 이미지 보존
- 게시글 상세보기 이미지 깨짐
- 가격 안나옴
    - 거래 하고싶은 위치 안나옴
- 업체 목록
    - 등록일자 폼 수정
- 업체등록
    - 전화번호 문자 막기

## 🚀 테스트 방법
-

## 📸 스크린샷 (필수)
-

## 💡 추가 설명
-

## ⛓️ 관련 이슈
Closes #이
